### PR TITLE
versions: Make api change complete

### DIFF
--- a/2016-01-06/swagger/definitions.json
+++ b/2016-01-06/swagger/definitions.json
@@ -110,8 +110,9 @@
         "format": "int64"
       },
       "modified": {
-        "description": "Last modified time in unix time format",
-        "type": "integer"
+        "description": "Last modified time",
+        "type": "string",
+        "format": "date-time"
       },
       "encrypted": {
         "description": "Whether this key is encrypted",

--- a/2016-01-06/swagger/object.json
+++ b/2016-01-06/swagger/object.json
@@ -193,6 +193,10 @@
           "X-QS-Encryption-Customer-Algorithm": {
             "description": "Encryption algorithm of the object",
             "type": "string"
+          },
+          "X-QS-Version-Id": {
+            "description": "version id of the object you created",
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
1. version_key.modified don't like key.modified, it's not a timestamp;
2. Add version-id header to put object response.